### PR TITLE
Created method param to deactivate response with summary

### DIFF
--- a/src/Horse.Paginate.pas
+++ b/src/Horse.Paginate.pas
@@ -24,7 +24,7 @@ const
 procedure Middleware(Req: THorseRequest; Res: THorseResponse; Next: {$IF DEFINED(FPC)}TNextProc{$ELSE}TProc{$ENDIF});
 
 function Paginate: THorseCallback; overload;
-function Paginate(APaginateOptions: THorsePaginateOptionSet = HORSE_PAGINATE_OPTION_ALL): THorseCallback; overload;
+function Paginate(APaginateOptions: THorsePaginateOptionSet): THorseCallback; overload;
 
 implementation
 

--- a/src/Horse.Paginate.pas
+++ b/src/Horse.Paginate.pas
@@ -15,16 +15,16 @@ uses
   Horse;
 
 type
-  THorsePaginateOption = (gpoReturnSummary);
+  THorsePaginateOption = (gpoIncludeSummary);
   THorsePaginateOptionSet = set of THorsePaginateOption;
 
 const
-  HORSE_PAGINATE_OPTION_ALL = [gpoReturnSummary];
+  HORSE_PAGINATE_OPTION_ALL = [gpoIncludeSummary];
 
 procedure Middleware(Req: THorseRequest; Res: THorseResponse; Next: {$IF DEFINED(FPC)}TNextProc{$ELSE}TProc{$ENDIF});
 
-function Paginate(APaginateOptions: THorsePaginateOptionSet = HORSE_PAGINATE_OPTION_ALL): THorseCallback; overload;
 function Paginate: THorseCallback; overload;
+function Paginate(APaginateOptions: THorsePaginateOptionSet = HORSE_PAGINATE_OPTION_ALL): THorseCallback; overload;
 
 implementation
 
@@ -85,8 +85,7 @@ begin
               LNewJsonArray.{$IF DEFINED(FPC)}Add{$ELSE}AddElement{$ENDIF}(LJsonArray.Items[i].Clone as {$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF});
           end;
 
-          if (gpoReturnSummary in PaginateOptionSet) or
-            Req.Headers.ContainsKey('include-summary') and (LowerCase(Req.Headers['include-summary']) = 'true') then
+          if (gpoIncludeSummary in PaginateOptionSet) then
           begin
             LJsonObjectResponse := TJsonObject.Create;
             LJsonObjectResponse.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}('docs', LNewJsonArray);


### PR DESCRIPTION
Created a set param to deactivate response with summary, just add a set value of a new type  `THorsePaginateOption` in `Paginate `midware method. The same behavior continues to backward compatibility