### PR TITLE
:sparkles: feat: adição para paginar json-string

### DIFF
--- a/src/Horse.Paginate.pas
+++ b/src/Horse.Paginate.pas
@@ -58,6 +58,19 @@ begin
         LPage := '1';
       LWebResponse := Res.RawWebResponse;
       LContent := Res.Content;
+
+      if (Length(LWebResponse.Content) > 0 ) and (LWebResponse.ContentType.Contains('application/json')) then
+      begin
+        try
+        {$IF DEFINED(FPC)}
+          Res.Content(GetJSON(LWebResponse.Content));
+        {$ELSE}
+          Res.Content(TJSONValue.ParseJSONValue(LWebResponse.Content));
+        {$ENDIF}
+        except
+        end;
+      end;
+
       if Assigned(LContent) and LContent.InheritsFrom({$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF}) then
       begin
         try

--- a/src/Horse.Paginate.pas
+++ b/src/Horse.Paginate.pas
@@ -56,9 +56,8 @@ begin
         LLimit := '25';
       if not Req.Query.TryGetValue('page', LPage) then
         LPage := '1';
-      LWebResponse := Res.RawWebResponse;
-      LContent := Res.Content;
 
+      LWebResponse := Res.RawWebResponse;
       if (Length(LWebResponse.Content) > 0 ) and (LWebResponse.ContentType.Contains('application/json')) then
       begin
         try
@@ -71,6 +70,7 @@ begin
         end;
       end;
 
+      LContent := Res.Content;
       if Assigned(LContent) and LContent.InheritsFrom({$IF DEFINED(FPC)}TJSONData{$ELSE}TJSONValue{$ENDIF}) then
       begin
         try


### PR DESCRIPTION
Foi adicionada uma validação para verificar se o conteúdo da resposta é diferente de vazio e o conteúdo é de tipo JSON. Isto é, se está usando a função Send com parâmetro string e ContentType application/json. Quando for esse cenário, vai setar o conteúdo como um objeto JSON para ser passível de paginação.